### PR TITLE
Update node-fetch version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -531,7 +531,7 @@
         "@discordjs/collection": "^0.1.5",
         "@discordjs/form-data": "^3.0.1",
         "abort-controller": "^3.0.0",
-        "node-fetch": "^2.6.0",
+        "node-fetch": "^2.6.1",
         "prism-media": "^1.2.0",
         "setimmediate": "^1.0.5",
         "tweetnacl": "^1.0.3",
@@ -1261,8 +1261,8 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "nodemon": {


### PR DESCRIPTION
Update node-fetch version because of a vulnerability in version 2.6.0.